### PR TITLE
feat: add --summary flag to show concise organization summary

### DIFF
--- a/organizer.py
+++ b/organizer.py
@@ -5,8 +5,8 @@ File Organizer CLI Tool
 Organizes files in a folder by type (extension) or by modified date.
 
 Usage:
-    python organizer.py --path test_files --mode type [--dry-run]
-    python organizer.py --path test_files --mode date [--dry-run]
+    python organizer.py --path test_files --mode type [--dry-run] [--summary]
+    python organizer.py --path test_files --mode date [--dry-run] [--summary]
 """
 
 import os
@@ -21,23 +21,25 @@ def main():
     parser.add_argument("--path", "-p", required=True, help="Path to the folder containing files.")
     parser.add_argument("--mode", "-m", choices=["type", "date"], required=True, help="Organize by 'type' or 'date'.")
     parser.add_argument("--dry-run", action="store_true", help="Preview file moves without actually moving files.")
+    parser.add_argument("--summary", action="store_true", help="Show only a summary of results (no detailed output).")
 
     args = parser.parse_args()
     folder = args.path
     mode = args.mode
     dry_run = args.dry_run
+    summary = args.summary
 
     if not os.path.exists(folder):
         print(f"Error: The folder '{folder}' does not exist.")
         return
 
     if mode == "type":
-        moved = organize_by_type(folder, dry_run=dry_run)
+        moved = organize_by_type(folder, dry_run=dry_run, summary=summary)
     else:
-        moved = organize_by_date(folder, dry_run=dry_run)
+        moved = organize_by_date(folder, dry_run=dry_run, summary=summary)
 
     action = "Would have organized" if dry_run else "Organized"
-    print(f"\nDone! {action} {moved} files in '{folder}' by {mode}.")
+    print(f"\n{action} {moved} files in '{folder}' by {mode}.")
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -3,7 +3,7 @@ import shutil
 from datetime import datetime
 
 
-def organize_by_type(folder: str, dry_run: bool = False) -> int:
+def organize_by_type(folder: str, dry_run: bool = False, summary: bool = False) -> int:
     """Organize files in the folder into subfolders by file extension."""
     count = 0
     for filename in os.listdir(folder):
@@ -11,17 +11,19 @@ def organize_by_type(folder: str, dry_run: bool = False) -> int:
         if os.path.isfile(file_path):
             ext = filename.split('.')[-1].lower()
             target_folder = os.path.join(folder, ext)
-            if dry_run:
-                print(f"Would move {filename} -> {ext}/")
-            else:
+            if not summary:
+                if dry_run:
+                    print(f"Would move {filename} -> {ext}/")
+                else:
+                    print(f"Moved {filename} -> {ext}/")
+            if not dry_run:
                 os.makedirs(target_folder, exist_ok=True)
                 shutil.move(file_path, os.path.join(target_folder, filename))
-                print(f"Moved {filename} -> {ext}/")
             count += 1
     return count
 
 
-def organize_by_date(folder: str, dry_run: bool = False) -> int:
+def organize_by_date(folder: str, dry_run: bool = False, summary: bool = False) -> int:
     """Organize files in the folder into subfolders by modified date (YYYY-MM-DD)."""
     count = 0
     for filename in os.listdir(folder):
@@ -30,11 +32,13 @@ def organize_by_date(folder: str, dry_run: bool = False) -> int:
             mod_time = os.path.getmtime(file_path)
             date_folder = datetime.fromtimestamp(mod_time).strftime("%Y-%m-%d")
             target_folder = os.path.join(folder, date_folder)
-            if dry_run:
-                print(f"Would move {filename} -> {date_folder}/")
-            else:
+            if not summary:
+                if dry_run:
+                    print(f"Would move {filename} -> {date_folder}/")
+                else:
+                    print(f"Moved {filename} -> {date_folder}/")
+            if not dry_run:
                 os.makedirs(target_folder, exist_ok=True)
                 shutil.move(file_path, os.path.join(target_folder, filename))
-                print(f"Moved {filename} -> {date_folder}/")
             count += 1
     return count


### PR DESCRIPTION
### What
- Added --summary flag to CLI
- When used, prints only the final summary message instead of details for each moved file

### Why
- Improves readability for large folders
- Gives users control over verbosity

### Notes
- Works with or without --dry-run
- Example usage:
  - python organizer.py --path test_files --mode type --summary
  - python organizer.py --path test_files --mode date --dry-run --summary
